### PR TITLE
Add integration tests for tlf script

### DIFF
--- a/tlf/integration_tests.py
+++ b/tlf/integration_tests.py
@@ -1,0 +1,72 @@
+import unittest
+from tlf import search_gulesider  # type: ignore
+
+
+class TestGulesider(unittest.TestCase):
+    def test_search_for_nonsense(self) -> None:
+        persons, companies = search_gulesider("gurbagurba")
+        self.assertEqual(len(persons), 0)
+        self.assertEqual(len(companies), 0)
+
+    def test_search_for_single_person(self) -> None:
+        persons, companies = search_gulesider("Mads Robert Johansen")
+        self.assertEqual(len(persons), 1)
+        self.assertEqual(len(companies), 0)
+        res = persons[0]
+        self.assertEqual(res.name, "Mads Robert Johansen")
+        self.assertEqual(res.street, "Otervegen 13")
+        self.assertEqual(res.area, "9017 Tromsø")
+        self.assertIn("959 62 392", res.phone_numbers)
+
+    def test_search_for_single_company(self) -> None:
+        persons, companies = search_gulesider("Blå Rock Cafe")
+        self.assertEqual(len(persons), 0)
+        self.assertEqual(len(companies), 1)
+        res = companies[0]
+        self.assertEqual(res.name, "Blå Rock Cafe AS")
+        self.assertEqual(res.street, "Strandgata 14")
+        self.assertEqual(res.area, "9008 Tromsø")
+        self.assertIn("77 61 00 20", res.phone_numbers)
+
+    def test_search_for_multiple_companies(self) -> None:
+        _, companies = search_gulesider("Blå Rock")
+        self.assertEqual(len(companies), 2)
+        first, second = companies
+        self.assertEqual(
+            str(first), "Blå Rock Cafe AS\nStrandgata 14\n9008 Tromsø\nTlf: 77 61 00 20"
+        )
+        self.assertEqual(str(second), "Blå Rock Eiendom AS\nStorgata 37\n9008 Tromsø")
+
+    def test_search_for_person_with_no_address(self) -> None:
+        persons, companies = search_gulesider("David Andreas Swan")
+        self.assertEqual(len(persons), 1)
+        self.assertEqual(len(companies), 0)
+        res = persons[0]
+        self.assertEqual(res.name, "David Andreas Swan")
+        self.assertEqual(res.street, "")
+        self.assertEqual(res.area, "")
+        self.assertIn("412 25 400", res.phone_numbers)
+
+    def test_search_for_company_with_no_phone(self) -> None:
+        persons, companies = search_gulesider("Chips og Dip AS")
+        self.assertEqual(len(persons), 0)
+        self.assertEqual(len(companies), 1)
+        res = companies[0]
+        self.assertEqual(res.name, "Chips og Dip AS")
+        self.assertEqual(res.street, "Prestenggata 5")
+        self.assertEqual(res.area, "9008 Tromsø")
+        self.assertEqual(res.phone_numbers, [])
+
+
+if __name__ == "__main__":
+    from sys import argv
+
+    if "-q" not in argv:
+        print("These are integration tests that hit the Gulesider server directly.")
+        if input("Are you sure you want to continue? [y/N] ").lower() not in (
+            "y",
+            "yes",
+        ):
+            print("Aborting test run")
+            exit()
+    unittest.main()

--- a/tlf/tlf.py
+++ b/tlf/tlf.py
@@ -1,13 +1,10 @@
+from dataclasses import dataclass
+from typing import Tuple
 import requests
 import sys
 
 # This might change when Gulesider is updated
-BASE_URL = "https://www.gulesider.no/_next/data/icrEtxkRx7HLangO6erlo/nb/search/"
-
-
-def filter_empty(dictionary):
-    "Removes all empty values from the given dictionary"
-    return {k: v for k, v in dictionary.items() if v}
+BASE_URL = "https://www.gulesider.no/_next/data/icrEtxkRx7HLangO6erlo/nb/search"
 
 
 def from_optional(dictionary: dict, *keys: str) -> str:
@@ -15,59 +12,56 @@ def from_optional(dictionary: dict, *keys: str) -> str:
     return " ".join(filter(None, (dictionary.get(key) for key in keys)))
 
 
-def person(item: dict) -> dict[str, str]:
-    address = item["addresses"][0]
-    return {
-        "name": from_optional(item["name"], *item["name"].keys()),
-        "street": from_optional(address, "streetName", "streetNumber"),
-        "area": from_optional(address, "postalCode", "postalArea"),
-        "phone_numbers": "\n".join(
-            f"Tlf: {p['number']}" for p in item.get("phones", [])
-        ),
-    }
+@dataclass
+class SearchResult:
+    """Represents a search result from Gulesider
+
+    Most properties can be empty, but printing the result directly
+    will handle the display logic for you.
+    """
+
+    name: str
+    street: str
+    area: str
+    phone_numbers: list[str]
+
+    def __init__(self, item: dict):
+        self.name = (
+            item["name"]
+            # Companies have names as plain strings
+            if isinstance(item["name"], str)
+            # But persons have name dictionaries with optional properties
+            else from_optional(item["name"], *item["name"].keys())
+        )
+        # Some results have no addresses
+        address = item["addresses"][0] if item["addresses"] else {}
+        self.street = from_optional(address, "streetName", "streetNumber")
+        self.area = from_optional(address, "postalCode", "postalArea")
+        self.phone_numbers = [p["number"] for p in item.get("phones", [])]
+
+    def __str__(self):
+        phone_numbers = "\n".join(f"Tlf: {p}" for p in self.phone_numbers)
+        return "\n".join(
+            filter(None, [self.name, self.street, self.area, phone_numbers])
+        )
 
 
-def company(item: dict) -> dict[str, str]:
-    address = item["addresses"][0]
-    return {
-        "name": item["name"],
-        "street": from_optional(address, "streetName", "streetNumber"),
-        "area": from_optional(address, "postalCode", "postalArea"),
-        "phone_number": "\n".join(
-            f"Tlf: {p['number']}" for p in item.get("phones", [])
-        ),
-    }
-
-
-def main(search_word: str):
+def search_gulesider(query: str) -> Tuple[list[SearchResult], list[SearchResult]]:
     # Searching for companies returns persons as well, so this url works for everything
-    resp = requests.get(
-        f"{BASE_URL}{search_word}/companies/1/0.json?query={search_word}&searchType=companies&page=1&id=0"
-    )
+    resp = requests.get(f"{BASE_URL}/{query}/companies/1/0.json?query={query}")
     # The response is for a SPA built on Next.js, so we can dig
     # directly into the page props for our data
-    raw_search_result = dict(resp.json())["pageProps"]
+    page_props = dict(resp.json())["pageProps"]
 
-    # Happens for unlisted numbers
-    if "initialState" not in raw_search_result:
-        print(f"No results for '{search_word}'")
-        sys.exit(1)
+    # No results can happen for unlisted numbers
+    if "initialState" not in page_props:
+        return [], []
 
-    state = raw_search_result["initialState"]
+    state = page_props["initialState"]
+    persons = [SearchResult(res) for res in state["persons"]]
+    companies = [SearchResult(res) for res in state["companies"]]
 
-    num_hits = state["totalHits"]
-    if num_hits == 0:
-        print(f"No results for '{search_word}'")
-        sys.exit(1)
-
-    companies = [filter_empty(company(res)) for res in state["companies"]]
-    persons = [filter_empty(person(res)) for res in state["persons"]]
-
-    plural = "s" if num_hits > 1 else ""
-    print(f"{num_hits} result{plural} for '{search_word}':\n")
-
-    for result in persons + companies:
-        print("\n".join(result.values()), end="\n\n")
+    return persons, companies
 
 
 if __name__ == "__main__":
@@ -78,4 +72,15 @@ if __name__ == "__main__":
         print(f"Usage: {prog} <name or number>")
         sys.exit()
 
-    main(" ".join(args))
+    query = " ".join(args)
+    persons, companies = search_gulesider(query)
+
+    num_hits = len(persons + companies)
+    if num_hits == 0:
+        print(f"No results for '{query}'")
+        sys.exit()
+
+    plural = "s" if num_hits > 1 else ""
+    print(f"{num_hits} result{plural} for '{query}':\n")
+
+    print("\n\n".join(str(res) for res in persons + companies))

--- a/tlf/tlf.py
+++ b/tlf/tlf.py
@@ -18,6 +18,47 @@ class SearchResult:
 
     Most properties can be empty, but printing the result directly
     will handle the display logic for you.
+
+    >>> SearchResult({
+    ...     "name": {
+    ...         "firstName": "Ola",
+    ...         "lastName": "Nordmann",
+    ...     },
+    ...     "addresses": [
+    ...         {
+    ...             "streetName": "Storgata",
+    ...             "streetNumber": "1",
+    ...             "postalCode": "1234",
+    ...             "postalArea": "Oslo",
+    ...         }
+    ...     ],
+    ...     "phones": [
+    ...         {
+    ...             "number": "12345678",
+    ...         }
+    ...     ],
+    ... })
+    SearchResult(name='Ola Nordmann', street='Storgata 1', area='1234 Oslo', phone_numbers=['12345678'])
+    >>> SearchResult({
+    ...     "name": "Nordmann AS",
+    ...     "addresses": [
+    ...         {
+    ...             "streetName": "Sjøgata",
+    ...             "streetNumber": "2",
+    ...             "postalCode": "9000",
+    ...             "postalArea": "Tromsø",
+    ...         }
+    ...     ],
+    ...     "phones": [
+    ...         {
+    ...             "number": "98765432",
+    ...         },
+    ...         {
+    ...             "number": "87654321",
+    ...         }
+    ...     ],
+    ... })
+    SearchResult(name='Nordmann AS', street='Sjøgata 2', area='9000 Tromsø', phone_numbers=['98765432', '87654321'])
     """
 
     name: str


### PR DESCRIPTION
* Replaced the untyped dictionaries that represented persons and companies with a unified `SearchResult` class, instances of which can be created from either kind of result dictionary from Gulesider.
* Added doctests to `SearchResult` class: run with `python -m doctest tlf.py`. Should these be split into a separate file?
* Split the actual searching out of the old `main` function and run the rest using the `if __name__ == '__main__'` idiom. The searching can now be tested programmatically. Since the tests will make network requests, I've called the file `integration_tests.py` and added a basic safeguard to prevent running them accidentally: you can either run the file directly with the `-q` flag (for quiet) to run it immediately or answer the prompt that otherwise appears.


Closes #14 